### PR TITLE
2 new themes, and a few fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,13 +234,13 @@
                 <table class="table" style="margin: 0 auto">
                     <tr>
                         <td>
-                            <div class="eternityupbtnlocked" style="opacity: 0"></div>
+                            <div class="eternityupbtnbought" style="opacity: 0"></div>
                         </td>
                         <td>
                             <button id="epmult" class="eternityupbtn" onclick="buyEPMult()">You gain 5 times more EP<p>Cost: 500 EP</button>
                         </td>
                         <td>
-                            <div class="eternityupbtnlocked" style="opacity: 0"></div>
+                            <div class="eternityupbtnbought" style="opacity: 0"></div>
                         </td>
                     </tr>
                 </table>

--- a/javascripts/game.js
+++ b/javascripts/game.js
@@ -4396,19 +4396,33 @@ function updateAutobuyers() {
         document.getElementById("autoBuyerSac").style.display = "inline-block"
     }
 
-    document.getElementById("interval1").innerHTML = "Current interval: " + (player.autobuyers[0].interval/1000).toFixed(2) + " seconds";
-    document.getElementById("interval2").innerHTML = "Current interval: " + (player.autobuyers[1].interval/1000).toFixed(2) + " seconds";
-    document.getElementById("interval3").innerHTML = "Current interval: " + (player.autobuyers[2].interval/1000).toFixed(2) + " seconds";
-    document.getElementById("interval4").innerHTML = "Current interval: " + (player.autobuyers[3].interval/1000).toFixed(2) + " seconds";
-    document.getElementById("interval5").innerHTML = "Current interval: " + (player.autobuyers[4].interval/1000).toFixed(2) + " seconds";
-    document.getElementById("interval6").innerHTML = "Current interval: " + (player.autobuyers[5].interval/1000).toFixed(2) + " seconds";
-    document.getElementById("interval7").innerHTML = "Current interval: " + (player.autobuyers[6].interval/1000).toFixed(2) + " seconds";
-    document.getElementById("interval8").innerHTML = "Current interval: " + (player.autobuyers[7].interval/1000).toFixed(2) + " seconds";
-    document.getElementById("intervalTickSpeed").innerHTML = "Current interval: " + (player.autobuyers[8].interval/1000).toFixed(2) + " seconds";
-    document.getElementById("intervalDimBoost").innerHTML = "Current interval: " + (player.autobuyers[9].interval/1000).toFixed(2) + " seconds";
-    document.getElementById("intervalGalaxies").innerHTML = "Current interval: " + (player.autobuyers[10].interval/1000).toFixed(2) + " seconds";
-    document.getElementById("intervalInf").innerHTML = "Current interval: " + (player.autobuyers[11].interval/1000).toFixed(2) + " seconds";
-
+    if (player.infinityUpgrades.includes("autoBuyerUpgrade")) {
+        document.getElementById("interval1").innerHTML = "Current interval: " + (player.autobuyers[0].interval/2000).toFixed(2) + " seconds";
+        document.getElementById("interval2").innerHTML = "Current interval: " + (player.autobuyers[1].interval/2000).toFixed(2) + " seconds";
+        document.getElementById("interval3").innerHTML = "Current interval: " + (player.autobuyers[2].interval/2000).toFixed(2) + " seconds";
+        document.getElementById("interval4").innerHTML = "Current interval: " + (player.autobuyers[3].interval/2000).toFixed(2) + " seconds";
+        document.getElementById("interval5").innerHTML = "Current interval: " + (player.autobuyers[4].interval/2000).toFixed(2) + " seconds";
+        document.getElementById("interval6").innerHTML = "Current interval: " + (player.autobuyers[5].interval/2000).toFixed(2) + " seconds";
+        document.getElementById("interval7").innerHTML = "Current interval: " + (player.autobuyers[6].interval/2000).toFixed(2) + " seconds";
+        document.getElementById("interval8").innerHTML = "Current interval: " + (player.autobuyers[7].interval/2000).toFixed(2) + " seconds";
+        document.getElementById("intervalTickSpeed").innerHTML = "Current interval: " + (player.autobuyers[8].interval/2000).toFixed(2) + " seconds";
+        document.getElementById("intervalDimBoost").innerHTML = "Current interval: " + (player.autobuyers[9].interval/2000).toFixed(2) + " seconds";
+        document.getElementById("intervalGalaxies").innerHTML = "Current interval: " + (player.autobuyers[10].interval/2000).toFixed(2) + " seconds";
+        document.getElementById("intervalInf").innerHTML = "Current interval: " + (player.autobuyers[11].interval/2000).toFixed(2) + " seconds";
+    } else {
+        document.getElementById("interval1").innerHTML = "Current interval: " + (player.autobuyers[0].interval/1000).toFixed(2) + " seconds";
+        document.getElementById("interval2").innerHTML = "Current interval: " + (player.autobuyers[1].interval/1000).toFixed(2) + " seconds";
+        document.getElementById("interval3").innerHTML = "Current interval: " + (player.autobuyers[2].interval/1000).toFixed(2) + " seconds";
+        document.getElementById("interval4").innerHTML = "Current interval: " + (player.autobuyers[3].interval/1000).toFixed(2) + " seconds";
+        document.getElementById("interval5").innerHTML = "Current interval: " + (player.autobuyers[4].interval/1000).toFixed(2) + " seconds";
+        document.getElementById("interval6").innerHTML = "Current interval: " + (player.autobuyers[5].interval/1000).toFixed(2) + " seconds";
+        document.getElementById("interval7").innerHTML = "Current interval: " + (player.autobuyers[6].interval/1000).toFixed(2) + " seconds";
+        document.getElementById("interval8").innerHTML = "Current interval: " + (player.autobuyers[7].interval/1000).toFixed(2) + " seconds";
+        document.getElementById("intervalTickSpeed").innerHTML = "Current interval: " + (player.autobuyers[8].interval/1000).toFixed(2) + " seconds";
+        document.getElementById("intervalDimBoost").innerHTML = "Current interval: " + (player.autobuyers[9].interval/1000).toFixed(2) + " seconds";
+        document.getElementById("intervalGalaxies").innerHTML = "Current interval: " + (player.autobuyers[10].interval/1000).toFixed(2) + " seconds";
+        document.getElementById("intervalInf").innerHTML = "Current interval: " + (player.autobuyers[11].interval/1000).toFixed(2) + " seconds";
+    }
 
     var maxedAutobuy = 0;
     for (let tier = 1; tier <= 8; ++tier) {

--- a/javascripts/game.js
+++ b/javascripts/game.js
@@ -371,12 +371,16 @@ function setTheme(name) {
 
 document.getElementById("theme").onclick = function () {
     if (player.options.theme === undefined) {
-        player.options.theme = "Dark";
-    } else if (player.options.theme === "Dark") {
-        player.options.theme = "Inverted";
-    } else if (player.options.theme === "Inverted") {
         player.options.theme = "Metro";
     } else if (player.options.theme === "Metro") {
+        player.options.theme = "Dark";
+    } else if (player.options.theme === "Dark") {
+        player.options.theme = "Dark Metro";
+    } else if (player.options.theme === "Dark Metro") {
+        player.options.theme = "Inverted";
+    } else if (player.options.theme === "Inverted") {
+        player.options.theme = "Inverted Metro";
+    } else if (player.options.theme === "Inverted Metro") {
         player.options.theme = undefined;
     } else {
         player.options.theme = undefined;

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -343,6 +343,7 @@
     width: 175px;
     height: 25px;
     font-family: Typewriter;
+    font-size: 0.8rem;
 }
 
 .secondarytabbtn:hover {
@@ -615,11 +616,11 @@
     display: none;
 }
 
-#footercontainer{
+#footercontainer {
     bottom: 0;
     position: fixed;
     width: 100%;
-    z-index: -1
+    z-index: 1;
 }
 
 
@@ -892,6 +893,7 @@
     transition-duration: 0.2s;
     border-radius: 4px;
     font-family: Typewriter;
+    cursor: pointer;
 }
 
 .eternityupbtnlocked:hover {

--- a/stylesheets/theme-Dark Metro.css
+++ b/stylesheets/theme-Dark Metro.css
@@ -1,0 +1,454 @@
+body {
+    background-image: url('../images/dark-bg.png');
+    background-position: center; 
+}
+
+* {
+    border-radius: 0px !important;
+}
+
+.container {
+    color: #757575 !important;
+}
+
+.statstab {
+    color: #757575 !important;
+}
+
+#coinAmount {
+    color: #E0E0E0 !important;
+}
+
+.tabbtn {
+    color: #E0E0E0 !important;
+    background: #455A64 !important;
+    border: 1px solid #1E88E5 !important;
+    box-shadow: 1px 1px 1px 0px black;
+}
+
+.tabbtn:hover {
+    background: #1E88E5 !important;
+}
+
+.secondarytabbtn {
+    color: #E0E0E0 !important;
+    background: #455A64 !important;
+    border: 1px solid #1E88E5 !important;
+    box-shadow: 1px 1px 1px 0px black;
+}
+
+.secondarytabbtn:hover {
+    background: #1E88E5 !important;
+}
+
+.storebtn {
+    background: #455A64 !important;
+    border: 1px solid #43A047 !important;
+    box-shadow: 1px 1px 1px 0px black;
+}
+
+.storebtn:hover {
+    background: #43A047 !important;
+}
+
+.unavailablebtn {
+    background: #37474F !important;
+    border: 1px solid #E53935 !important;
+    box-shadow: 1px 1px 1px 0px black;
+}
+
+.unavailablebtn:hover {
+    background: #E53935 !important;
+}
+
+.newdim {
+    color: black !important;
+    background: #455A64 !important;
+    border: 1px solid #43A047 !important;
+    box-shadow: 1px 1px 1px 0px black;
+}
+
+.newdim:hover {
+    background: #43A047 !important;
+}
+
+.newdimlocked {
+    background: #37474F !important;
+    border: 1px solid #E53935 !important;
+    box-shadow: 1px 1px 1px 0px black;
+}
+
+.newdimlocked:hover {
+    background: #E53935 !important;
+}
+
+.infinitybtn {
+    color: black !important;
+    background: white !important;
+    border: 1px solid #FF9800 !important;
+    box-shadow: 1px 1px 1px 0px black;
+}
+
+.infinitybtn:hover {
+    background: #FF9800 !important;
+}
+
+.eternitybtn {
+    color: #673AB7 !important;
+    border: 2px solid #673AB7 !important;
+}
+
+.eternitybtn:hover {
+    background: white !important;
+}
+
+.eternitytabbtn {
+    color: #673AB7 !important;
+    border: 1px solid #673AB7 !important;
+    box-shadow: 1px 1px 1px 0px black;
+}
+
+.completedrow {
+    background: #1B5E20 !important;
+}
+
+.achievementunlocked {
+    background-color: #4CAF50 !important;
+    border: 1px solid #388E3C !important;
+}
+
+.achievementlocked {
+    background-color: #9E9E9E !important;
+    border: 1px solid #E53935 !important;
+}
+
+#infinityPoints1 {
+    color: #757575 !important;
+}
+
+#infPowAmount {
+    color: #FF9800 !important;
+}
+
+#infDimMultAmount {
+    color: #FF9800 !important;
+}
+
+#timeShardAmount {
+    color: #673AB7 !important;
+}
+
+#tickThreshold {
+    color: #673AB7 !important;
+}
+
+.infinistorebtn1 {
+    border: 1px solid black !important;
+}
+
+.infinistorebtn2 {
+    border: 1px solid black !important;
+}
+
+.infinistorebtn3 {
+    border: 1px solid black !important;
+}
+
+.infinistorebtn4 {
+    border: 1px solid black !important;
+}
+
+.infinistorebtn1:hover {
+    background: #9C27B0 !important;
+}
+
+.infinistorebtn2:hover {
+    background: #F44336 !important;
+}
+
+.infinistorebtn3:hover {
+    background: #FFEB3B !important;
+}
+
+.infinistorebtn4:hover {
+    background: #00BCD4 !important;
+}
+
+.infinistorebtnbought {
+    background: #43A047 !important;
+    border: 1px solid black !important;
+}
+
+.infinimultbtn {
+    color: #E53935 !important;
+    border: 1px solid #00BCD4 !important;
+}
+
+.infinimultbtn:hover {
+    color: black !important;
+    background: #00BCD4 !important;
+    border: 1px solid black !important;
+}
+
+.infinistorebtnlocked {
+    border: 1px solid #616161 !important;
+    background: #9E9E9E !important;
+}
+
+.infinistorebtnlocked:hover {
+    background: #BDBDBD !important;
+}
+
+.autobuyerbtn {
+    border: 1px solid #FF9800 !important;
+    margin-bottom: -1px;
+}
+
+.autobuyerbtn:hover {
+    background: #FF9800 !important;
+    border: #FF9800 !important;
+}
+
+.postinfcrunch {
+    color: black !important;
+    background: #455A64 !important;
+    border: 1px solid #1E88E5 !important;
+    box-shadow: 1px 1px 1px 0px black;
+}
+
+.postinfcrunch:hover {
+    background: #1E88E5 !important;
+    border: 1px solid #1E88E5 !important;
+}
+
+.EPAmount1 {
+    color: #673AB7;
+}
+
+.EPAmount2 {
+    color: #673AB7;
+}
+
+.IPAmount1 {
+    color: #FF9800;
+}
+
+.IPAmount2 {
+    color: #FF9800;
+}
+
+.timetheorembtn {
+    background: #212121 !important;
+    color: #00BCD4 !important;
+    border: 1px solid #00BCD4 !important;
+}
+
+.timetheorembtn:hover {
+    color: #212121 !important;
+    background: #00BCD4 !important;
+}
+
+.timetheorembtnlocked {
+    background: #9E9E9E !important;
+    border: none !important;
+    box-shadow: 1px 1px 1px 0px #000;
+}
+
+.timetheorembtnlocked:hover {
+    background: #E53935 !important;
+}
+
+.timestudy {
+    color: #673AB7 !important;
+    border: 1px solid #4527A0 !important;
+    animation: metroStudyGlowIn 5s infinite !important;
+}
+
+.timestudy.normaldimstudy {
+    animation: normalDimStudyGlowIn 5s infinite !important;
+}
+
+.timestudy.infdimstudy {
+    animation: infDimStudyGlowIn 5s infinite !important;
+}
+
+.timestudy.timedimstudy {
+    animation: timeDimStudyGlowIn 5s infinite !important;
+}
+
+.timestudy.activestudy {
+    animation: activeStudyGlowIn 5s infinite !important;
+}
+
+.timestudy.passivestudy {
+    animation: passiveStudyGlowIn 5s infinite !important;
+}
+
+.timestudy.idlestudy {
+    animation: idleStudyGlowIn 5s infinite !important;
+}
+
+.timestudy:hover {
+    color: #EEEEEE !important;
+    background: #512DA8 !important;
+}
+
+.timestudy.normaldimstudy:hover {
+    color: #EEEEEE !important;
+    background: #22aa48 !important;
+}
+
+.timestudy.infdimstudy:hover {
+    color: #EEEEEE !important;
+    background: #B67F33 !important;
+}
+
+.timestudy.timedimstudy:hover {
+    color: #EEEEEE !important;
+    background: #B241E3 !important;
+}
+
+.timestudy.activestudy:hover {
+    color: #EEEEEE !important;
+    background: #FF0100 !important;
+}
+
+.timestudy.idlestudy:hover {
+    color: #EEEEEE !important;
+    background: #0080ff !important;
+}
+
+.timestudybought {
+    color: black !important;
+    background: #673AB7 !important;
+    border: 1px solid black !important;
+}
+
+.timestudybought.normaldimstudy {
+    background: #22aa48 !important;
+}
+
+.timestudybought.infdimstudy {
+    background: #B67F33 !important;
+}
+
+.timestudybought.timedimstudy {
+    background: #B241E3 !important;
+}
+
+.timestudybought.activestudy {
+    background: #FF0100 !important;
+}
+
+.timestudybought.passivestudy {
+    background: #5E33B6 !important;
+}
+
+.timestudybought.idlestudy {
+    background: #0080ff !important;
+}
+
+.timestudylocked {
+    color: black !important;
+    background: #9E9E9E !important;
+    box-shadow: 1px 1px 1px 0px #000;
+    border: none !important;
+}
+
+.timestudylocked.normaldimstudylocked {
+    background: #94a89a !important;
+}
+
+.timestudylocked.infdimstudylocked {
+    background: #a8a094 !important;
+}
+
+.timestudylocked.timedimstudylocked {
+    background: #a294a8 !important;
+}
+
+.timestudylocked.activestudylocked {
+    background: #a89494 !important;
+}
+
+.timestudylocked.passivestudylocked {
+    background: #9b94a8 !important;
+}
+
+.timestudylocked.idlestudylocked {
+    background: #949ea8 !important;
+}
+
+.timestudylocked:hover {
+    background: #E53935 !important;
+}
+
+.eternityupbtn {
+    color: #673AB7 !important;
+    border: 1px solid #673AB7 !important;
+    box-shadow: 1px 1px 1px 0px #9E9E9E;
+}
+
+.eternityupbtn:hover {
+    color: #511568;
+    background: white;
+}
+
+.eternityupbtnlocked {
+    background: #9E9E9E !important;
+    border: 1px solid black !important;
+
+}
+
+.eternityupbtnlocked:hover {
+    background: #BDBDBD !important;
+}
+
+.eternityupbtnbought {
+    color: black !important;
+    background: #673AB7 !important;
+    border: 1px solid black !important;
+}
+
+.challengediv {
+    background-color: #455A64 !important;
+    border: 1px solid black !important;
+}
+
+.infchallengediv {
+    border: 1px solid black !important;
+}
+
+.challengesbtn {
+    border: 3px solid #43A047 !important;
+    border-bottom-color: #388E3C !important;
+    border-right-color: #388E3C !important;
+}
+
+.challengesbtn:hover {
+    background: #43A047 !important;
+}
+
+.completedchallengesbtn {
+    background: #43A047 !important;
+    border: 3px solid #43A047 !important;
+    border-bottom-color: #388E3C !important;
+    border-right-color: #388E3C !important;
+}
+
+.milestonereward {
+    background: #673AB7 !important;
+    border: 1px solid #512DA8 !important;
+}
+
+.milestonerewardlocked {
+    background: #9E9E9E !important;
+    box-shadow: 1px 1px 1px 0px #000;
+    border: none !important;
+}
+
+@keyframes metroStudyGlowIn {
+    0%  {box-shadow: inset 0px 0px 3px 0px #673AB7;}
+    50% {box-shadow: inset 0px 0px 20px 0px #673AB7;}
+    100%  {box-shadow: inset 0px 0px 3px 0px #673AB7;}
+}

--- a/stylesheets/theme-Inverted Metro.css
+++ b/stylesheets/theme-Inverted Metro.css
@@ -1,0 +1,422 @@
+* {
+    border-radius: 0px !important;
+}
+
+body {
+    filter: invert(100%);
+    background-color: black !important;
+}
+
+.popup {
+    border: 1px solid black !important;
+}
+
+.tabbtn {
+    background: #EEEEEE !important;
+    border: 1px solid #2196F3 !important;
+    box-shadow: 1px 1px 1px 0px #9E9E9E;
+}
+
+.tabbtn:hover {
+    background: #2196F3 !important;
+    border: 1px solid #2196F3 !important;
+}
+
+.secondarytabbtn {
+    background: #EEEEEE !important;
+    border: 1px solid #2196F3 !important;
+    box-shadow: 1px 1px 1px 0px #9E9E9E;
+}
+
+.secondarytabbtn:hover {
+    background: #2196F3 !important;
+    border: 1px solid #2196F3 !important;
+}
+
+.storebtn {
+    background: #EEEEEE !important;
+    border: 1px solid #66BB6A !important;
+    box-shadow: 1px 1px 1px 0px #9E9E9E;
+}
+
+.storebtn:hover {
+    background: #66BB6A !important;
+}
+
+.unavailablebtn {
+    background: #9E9E9E !important;
+    border: 1px solid #EF5350 !important;
+    box-shadow: 1px 1px 1px 0px #9E9E9E;
+}
+
+.unavailablebtn:hover {
+    background: #EF5350 !important;
+}
+
+.newdim {
+    color: black !important;
+    background: #EEEEEE !important;
+    border: 1px solid #66BB6A !important;
+    box-shadow: 1px 1px 1px 0px #9E9E9E;
+}
+
+.newdim:hover {
+    background: #66BB6A !important;
+}
+
+.newdimlocked {
+    background: #9E9E9E !important;
+    border: 1px solid #EF5350 !important;
+    box-shadow: 1px 1px 1px 0px #9E9E9E;
+}
+
+.newdimlocked:hover {
+    background: #EF5350 !important;
+}
+
+.infinitybtn {
+    border: 1px solid #FF9800 !important;
+    box-shadow: 1px 1px 1px 0px #9E9E9E;
+}
+
+.infinitybtn:hover {
+    background: #FF9800 !important;
+}
+
+.eternitybtn {
+    color: #673AB7 !important;
+    border: 2px solid #673AB7 !important;
+}
+
+.eternitybtn:hover {
+    background: white !important;
+}
+
+.eternitytabbtn {
+    color: #673AB7 !important;
+    border: 1px solid #673AB7 !important;
+    box-shadow: 1px 1px 1px 0px #9E9E9E;
+}
+
+.completedrow {
+    background: #1B5E20 !important;
+}
+
+.achievementunlocked {
+    background-color: #66BB6A !important;
+    border: 1px solid #43A047 !important;
+}
+
+.achievementlocked {
+    background-color: #9E9E9E !important;
+    border: 1px solid #EF5350 !important;
+}
+
+.infinistorebtn1 {
+    border: 1px solid black !important;
+}
+
+.infinistorebtn2 {
+    border: 1px solid black !important;
+}
+
+.infinistorebtn3 {
+    border: 1px solid black !important;
+}
+
+.infinistorebtn4 {
+    border: 1px solid black !important;
+}
+
+.infinistorebtn1:hover {
+    background: #9C27B0 !important;
+}
+
+.infinistorebtn2:hover {
+    background: #F44336 !important;
+}
+
+.infinistorebtn3:hover {
+    background: #FFEB3B !important;
+}
+
+.infinistorebtn4:hover {
+    background: #00BCD4 !important;
+}
+
+.infinistorebtnbought {
+    background: #66BB6A !important;
+    border: 1px solid black !important;
+}
+
+.infinimultbtn {
+    color: #EF5350 !important;
+    border: 1px solid #00BCD4 !important;
+}
+
+.infinimultbtn:hover {
+    color: black !important;
+    background: #00BCD4 !important;
+    border: 1px solid black !important;
+}
+
+.infinistorebtnlocked {
+    border: 1px solid #616161 !important;
+    background: #9E9E9E !important;
+}
+
+.infinistorebtnlocked:hover {
+    background: #BDBDBD !important;
+}
+
+.autobuyerbtn {
+    border: 1px solid #E91E63 !important;
+    margin-bottom: -1px;
+}
+
+.autobuyerbtn:hover {
+    background: #FF9800 !important;
+    border: #FF9800 !important;
+}
+
+.postinfcrunch {
+    background: #EEEEEE !important;
+    border: 1px solid #2196F3 !important;
+    box-shadow: 1px 1px 1px 0px #9E9E9E;
+}
+
+.postinfcrunch:hover {
+    background: #2196F3 !important;
+    border: 1px solid #2196F3 !important;
+}
+
+.EPAmount1 {
+    color: #673AB7;
+}
+
+.EPAmount2 {
+    color: #673AB7;
+}
+
+.IPAmount1 {
+    color: #FF9800;
+}
+
+.IPAmount2 {
+    color: #FF9800;
+}
+
+.timetheorembtn {
+    background: #212121 !important;
+    color: #00BCD4 !important;
+    border: 1px solid #00BCD4 !important;
+}
+
+.timetheorembtn:hover {
+    color: #212121 !important;
+    background: #00BCD4 !important;
+}
+
+.timetheorembtnlocked {
+    background: #9E9E9E !important;
+    border: none !important;
+    box-shadow: 1px 1px 1px 0px #000;
+}
+
+.timetheorembtnlocked:hover {
+    background: #EF5350 !important;
+}
+
+.timestudy {
+    color: #673AB7 !important;
+    border: 1px solid #4527A0 !important;
+    animation: metroStudyGlowIn 5s infinite !important;
+}
+
+.timestudy.normaldimstudy {
+    animation: normalDimStudyGlowIn 5s infinite !important;
+}
+
+.timestudy.infdimstudy {
+    animation: infDimStudyGlowIn 5s infinite !important;
+}
+
+.timestudy.timedimstudy {
+    animation: timeDimStudyGlowIn 5s infinite !important;
+}
+
+.timestudy.activestudy {
+    animation: activeStudyGlowIn 5s infinite !important;
+}
+
+.timestudy.passivestudy {
+    animation: passiveStudyGlowIn 5s infinite !important;
+}
+
+.timestudy.idlestudy {
+    animation: idleStudyGlowIn 5s infinite !important;
+}
+
+.timestudy:hover {
+    color: #EEEEEE !important;
+    background: #512DA8 !important;
+}
+
+.timestudy.normaldimstudy:hover {
+    color: #EEEEEE !important;
+    background: #22aa48 !important;
+}
+
+.timestudy.infdimstudy:hover {
+    color: #EEEEEE !important;
+    background: #B67F33 !important;
+}
+
+.timestudy.timedimstudy:hover {
+    color: #EEEEEE !important;
+    background: #B241E3 !important;
+}
+
+.timestudy.activestudy:hover {
+    color: #EEEEEE !important;
+    background: #FF0100 !important;
+}
+
+.timestudy.idlestudy:hover {
+    color: #EEEEEE !important;
+    background: #0080ff !important;
+}
+
+.timestudybought {
+    color: black !important;
+    background: #673AB7 !important;
+    border: 1px solid black !important;
+}
+
+.timestudybought.normaldimstudy {
+    background: #22aa48 !important;
+}
+
+.timestudybought.infdimstudy {
+    background: #B67F33 !important;
+}
+
+.timestudybought.timedimstudy {
+    background: #B241E3 !important;
+}
+
+.timestudybought.activestudy {
+    background: #FF0100 !important;
+}
+
+.timestudybought.passivestudy {
+    background: #5E33B6 !important;
+}
+
+.timestudybought.idlestudy {
+    background: #0080ff !important;
+}
+
+.timestudylocked {
+    color: black !important;
+    background: #9E9E9E !important;
+    box-shadow: 1px 1px 1px 0px #000;
+    border: none !important;
+}
+
+.timestudylocked.normaldimstudylocked {
+    background: #94a89a !important;
+}
+
+.timestudylocked.infdimstudylocked {
+    background: #a8a094 !important;
+}
+
+.timestudylocked.timedimstudylocked {
+    background: #a294a8 !important;
+}
+
+.timestudylocked.activestudylocked {
+    background: #a89494 !important;
+}
+
+.timestudylocked.passivestudylocked {
+    background: #9b94a8 !important;
+}
+
+.timestudylocked.idlestudylocked {
+    background: #949ea8 !important;
+}
+
+.timestudylocked:hover {
+    background: #EF5350 !important;
+}
+
+.eternityupbtn {
+    color: #673AB7 !important;
+    border: 1px solid #673AB7 !important;
+    box-shadow: 1px 1px 1px 0px #9E9E9E;
+}
+
+.eternityupbtn:hover {
+    color: #511568;
+    background: white;
+}
+
+.eternityupbtnlocked {
+    background: #9E9E9E !important;
+    border: 1px solid black !important;
+
+}
+
+.eternityupbtnlocked:hover {
+    background: #BDBDBD !important;
+}
+
+.eternityupbtnbought {
+    color: black !important;
+    background: #673AB7 !important;
+    border: 1px solid black !important;
+}
+
+.challengediv {
+    border: 1px solid black !important;
+}
+
+.infchallengediv {
+    border: 1px solid black !important;
+}
+
+.challengesbtn {
+    border: 3px solid #43A047 !important;
+    border-bottom-color: #388E3C !important;
+    border-right-color: #388E3C !important;
+}
+
+.challengesbtn:hover {
+    background: #66BB6A !important;
+}
+
+.completedchallengesbtn {
+    background: #66BB6A !important;
+    border: 3px solid #43A047 !important;
+    border-bottom-color: #388E3C !important;
+    border-right-color: #388E3C !important;
+}
+
+.milestonereward {
+    background: #673AB7 !important;
+    border: 1px solid #512DA8 !important;
+}
+
+.milestonerewardlocked {
+    background: #9E9E9E !important;
+    box-shadow: 1px 1px 1px 0px #000;
+    border: none !important;
+}
+
+@keyframes metroStudyGlowIn {
+    0%  {box-shadow: inset 0px 0px 3px 0px #673AB7;}
+    50% {box-shadow: inset 0px 0px 20px 0px #673AB7;}
+    100%  {box-shadow: inset 0px 0px 3px 0px #673AB7;}
+}


### PR DESCRIPTION
added dark metro theme
added inverted metro theme
changed order in which themes cycle through
made autobuyers display double the speed if you have the double speed upgrade (0.10 > 0.05, 2.44 > 1.22, etc)
made secondary tab button font size 0.8rem to fix an issue with the text on firefox
made #footercontainer have a z-index of 1 instead of -1 to fix issues with mousing over it
made the locked eternity upgrade buttons have a cursor on hover to match with the locked infinity upgrades
renamed the hidden centering divs due to the change listed above