### PR TITLE
 increased display precision of times below 10 seconds, fix allowing you to start EC10 without having it purchased

### DIFF
--- a/javascripts/game.js
+++ b/javascripts/game.js
@@ -3165,7 +3165,7 @@ function buyMaxTickSpeed() {
 }
 
 function timeDisplay(time) {
-    if (time <= 100) return (time/10).toFixed(2) + " seconds"
+    if (time <= 100) return (time/10).toFixed(3) + " seconds"
     time = Decimal.floor(time / 10)
 
 
@@ -3187,6 +3187,7 @@ function preformat(int) {
 }
 
 function timeDisplayShort(time) {
+    if (time <= 100) return (time/10).toFixed(3) + " seconds"
     if (time <= 600) return (time/10).toFixed(2) + " seconds"
     time = Decimal.floor(time / 10)
     return preformat(Decimal.floor((time) / 3600)) + ":" + preformat(Decimal.floor((time % 3600) / 60)) + ":" + preformat(Decimal.floor(time % 60))

--- a/javascripts/game.js
+++ b/javascripts/game.js
@@ -6739,7 +6739,7 @@ document.getElementById("ec12unl").onclick = function() {
 }
 
 function startEternityChallenge(name, startgoal, goalIncrease) {
-    if (!name.includes(player.eternityChallUnlocked)) return
+    if (player.eternityChallUnlocked !== 0 && !name.includes(player.eternityChallUnlocked)) return
     if((player.options.challConf) || name == "" ? true :  (confirm("You will start over with just your time studies, eternity upgrades and achievements. You need to reach a set IP with special conditions."))) {
         player = {
             money: new Decimal(10),


### PR DESCRIPTION
increased display precision of times below 10 seconds because they weren't accurate enough
fix allowing you to start EC10 without having it purchased (turns out the check was evaluating to true because EC10 has a 0 in the name)