### PR TITLE
Updated Strategy guide link

### DIFF
--- a/howto.html
+++ b/howto.html
@@ -262,7 +262,7 @@ Tachyon Particles generate another currency, Dilated Time. Dilated time is trans
 Dilation Upgrades are upgrades that are purchasable with Dilated Time. Some upgrades improve the amount of Dilated Time you gain or reset your free galaxies but decrease the threshold required to get to them. In addition, there is also a TT generator as one of the Dilation upgrades. The first row of dilation upgrades is purchasable as many times as possible, but the rest cannot. 
 </div> 
 <hr id='div18hr'> 
-    <a href="https://www.reddit.com/r/AntimatterDimensions/comments/73jhqe/patashus_antimatter_dimensions_guide/?utm_content=title&utm_medium=hot&utm_source=reddit&utm_name=AntimatterDimensions">Strategy Guide</a>
+    <a href="http://antimatter-dimensions.wikia.com/wiki/Guide">Strategy Guide</a>
   </body>
   <script src='javascripts/howto.js'></script>
   </html>


### PR DESCRIPTION
Updated Strategy guide link. Instead of linking to the reddit guide, it links to the wikia guide page, which is longer, and covers more in game stuff