### PR TITLE
Fix spoiler mode without imported save

### DIFF
--- a/javascripts/howto.js
+++ b/javascripts/howto.js
@@ -29,9 +29,10 @@ function get_save(name) {
 }
 
 function load_game() {
-    var save_data = get_save('dimensionSave');
+    const save_data = get_save('dimensionSave');
     if (!save_data) return;
-	player = save_data;
+    const save_to_use = save_data.saves[save_data.current]
+    player = save_to_use;
 }
 
 function showspoilers() {


### PR DESCRIPTION
The spoiler mode swap breaks on the 11th div without an imported save, since the normal site save fallback wasn't working properly with the save slot system.