### PR TITLE
Added screen reader accessibility to the achievements screen

### DIFF
--- a/javascripts/core/achievements.js
+++ b/javascripts/core/achievements.js
@@ -198,6 +198,22 @@ function giveAchievement(name) {
     updateAchievements();
 }
 
+function updateAchievementAria(domObj, isSecret=false) {
+  var isLocked = domObj.classList.contains("achievementlocked") || domObj.classList.contains("achievementhidden");
+  var label_text = (isLocked) ? "(Locked) " : "";
+  label_text += domObj.id;
+  // We only update labels with differing tooltips, which means that secret achievements should only be updated if they're unlocked.
+  if(!isSecret || isSecret && !isLocked) {
+    // Add a slight pause for screen readers, if necessary
+    var punctuation_expr = /[.,:!?]$/;
+    if (!punctuation_expr.test(label_text)) {
+      label_text += ".";
+    }
+    label_text += " " + domObj.getAttribute("ach-tooltip");
+  }
+  domObj.setAttribute("aria-label", label_text);
+}
+
 function updateAchievements() {
   var amount = 0
   for (var i=1; i<document.getElementById("achievementtable").children[0].children.length+1; i++) {
@@ -208,9 +224,13 @@ function updateAchievements() {
           var name = allAchievements["r"+achNum]
           if (player.achievements.includes("r"+achNum)) {
               n++
-              document.getElementById(name).className = "achievementunlocked"
+              var domObj = document.getElementById(name);
+              domObj.className = "achievementunlocked";
+              updateAchievementAria(domObj);
           } else {
-              document.getElementById(name).className = "achievementlocked"
+              var domObj = document.getElementById(name);
+              domObj.className = "achievementlocked";
+              updateAchievementAria(domObj);
           }
       }
       if (n == 8) {
@@ -228,11 +248,15 @@ function updateAchievements() {
           var name = allAchievements["s"+achNum]
           if (player.achievements.includes("s"+achNum)) {
               n++
-              document.getElementById(name).setAttribute('ach-tooltip', secretAchievementTooltips["s"+achNum])
-              document.getElementById(name).className = "achievementunlocked"
+              var domObj = document.getElementById(name);
+              domObj.setAttribute('ach-tooltip', secretAchievementTooltips["s"+achNum]);
+              domObj.className = "achievementunlocked";
+              updateAchievementAria(domObj, true);
           } else {
-              document.getElementById(name).className = "achievementhidden"
-              document.getElementById(name).setAttribute('ach-tooltip', (name[name.length-1] !== "?" && name[name.length-1] !== "!" && name[name.length-1] !== ".") ? name+"." : name)
+              var domObj = document.getElementById(name);
+              domObj.className = "achievementhidden";
+              domObj.setAttribute('ach-tooltip', (name[name.length-1] !== "?" && name[name.length-1] !== "!" && name[name.length-1] !== ".") ? name+"." : name);
+              updateAchievementAria(domObj, true);
           }
       }
       if (n == 8) {

--- a/javascripts/core/achievements.js
+++ b/javascripts/core/achievements.js
@@ -200,7 +200,7 @@ function giveAchievement(name) {
 
 function updateAchievementAria(domObj, isSecret=false) {
   var isLocked = domObj.classList.contains("achievementlocked") || domObj.classList.contains("achievementhidden");
-  var label_text = (isLocked) ? "(Locked) " : "";
+  var label_text = (!isLocked) ? "(Completed) " : "";
   // Retrieve achievement row, trimming off the "r" or "s"
   label_text += allAchievementNums[domObj.id].substring(1) + ", ";
   label_text += domObj.id;

--- a/javascripts/core/achievements.js
+++ b/javascripts/core/achievements.js
@@ -201,6 +201,8 @@ function giveAchievement(name) {
 function updateAchievementAria(domObj, isSecret=false) {
   var isLocked = domObj.classList.contains("achievementlocked") || domObj.classList.contains("achievementhidden");
   var label_text = (isLocked) ? "(Locked) " : "";
+  // Retrieve achievement row, trimming off the "r" or "s"
+  label_text += allAchievementNums[domObj.id].substring(1) + ", ";
   label_text += domObj.id;
   // We only update labels with differing tooltips, which means that secret achievements should only be updated if they're unlocked.
   if(!isSecret || isSecret && !isLocked) {


### PR DESCRIPTION
Hello.

Your game happens to be accessible to those using assistive technologies such as NVDA and Jaws. The only issue were the achievements, which were rendered as images with no apparent text. I have remedied this problem by using the aria-label attribute of the achievement divs, which allows for assistive technologies to get more information about an object without disrupting the visual layout. I would appreciate if you could merge this so that blind users wouldn't be forced to look at the code and figure out what they still have left to unlock.